### PR TITLE
Replace `inputFile` by `inputTextFile`

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,7 +11,7 @@ def buildDir := defaultBuildDir
 
 def md4cOTarget (pkg : Package) (srcName : String) : FetchM (BuildJob FilePath) := do
   let oFile := pkg.dir / buildDir / md4cDir / ⟨ srcName ++ ".o" ⟩
-  let srcTarget ← inputFile <| pkg.dir / md4cDir / ⟨ srcName ++ ".c" ⟩
+  let srcTarget ← inputTextFile <| pkg.dir / md4cDir / ⟨ srcName ++ ".c" ⟩
   buildFileAfterDep oFile srcTarget fun srcFile => do
     if Platform.isWindows then
       let flags := #["-I", ((← getLeanIncludeDir) / "clang").toString,
@@ -24,7 +24,7 @@ def md4cOTarget (pkg : Package) (srcName : String) : FetchM (BuildJob FilePath) 
 
 def wrapperOTarget (pkg : Package) : FetchM (BuildJob FilePath) := do
   let oFile := pkg.dir / buildDir / wrapperDir / ⟨ wrapperName ++ ".o" ⟩
-  let srcTarget ← inputFile <| pkg.dir / wrapperDir / ⟨ wrapperName ++ ".c" ⟩
+  let srcTarget ← inputTextFile <| pkg.dir / wrapperDir / ⟨ wrapperName ++ ".c" ⟩
   buildFileAfterDep oFile srcTarget fun srcFile => do
     if Platform.isWindows then
       let flags := #["-I", (← getLeanIncludeDir).toString,


### PR DESCRIPTION
`Lake.inputFile` is now deprecated. It should be replaced by either `inputTextFile` or `inputBinFile`, depending on whether line endings should be normalised to be platform-independent or not. I believe here they should be normalised, so this PR replaces the two `inputFile` by `inputTextFile`.

Context is that all users downstream of Mathlib are currently getting warnings that MD4Lean uses the deprecated `inputFile` whenever they run `lake update`.