### PR TITLE
fix: compatibility with new FFI representations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Here, "original" means to use the lean-toolchain file's contents in the repository
+        lean-version: ["original", "v4.21.0", "v4.22.0-rc3", "nightly-2025-08-04"]
+    name: CI (${{ matrix.lean-version }})
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set Lean version
+        if: matrix.lean-version != 'original'
+        run: echo "${{ matrix.lean-version }}" > lean-toolchain
+
       # uses lean standard action with all default input values
       - uses: leanprover/lean-action@v1

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2025-07-01
+leanprover/lean4:4.22.0-rc4

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.21.0-rc2
+leanprover/lean4:nightly-2025-07-01

--- a/wrapper/wrapper.c
+++ b/wrapper/wrapper.c
@@ -273,7 +273,7 @@ static int leave_block_callback(MD_BLOCKTYPE type, void *detail, void *userdata)
         lean_object *ul = lean_alloc_ctor(1, 1, 5); // 4 bytes for char, 1 for bool
         lean_ctor_set(ul, 0, items);
         lean_ctor_set_uint32(ul, sizeof(void*), ul_detail.mark);
-        lean_ctor_set_uint8(ul, sizeof(void *) + sizeof(uint32_t), is_tight);
+        lean_ctor_set_uint8(ul, sizeof(void*) + sizeof(uint32_t), is_tight);
         #endif
 
         parse_stack_save(stack, ul);
@@ -304,7 +304,7 @@ static int leave_block_callback(MD_BLOCKTYPE type, void *detail, void *userdata)
         lean_ctor_set(ol, 0, lean_unsigned_to_nat(ol_detail.start));
         lean_ctor_set(ol, 1, items);
         lean_ctor_set_uint32(ol, 2 * sizeof(void*), ol_detail.mark_delimiter);
-        lean_ctor_set_uint8(ol, 2 * sizeof(void *) + sizeof(uint32_t), is_tight);
+        lean_ctor_set_uint8(ol, 2 * sizeof(void*) + sizeof(uint32_t), is_tight);
         #endif
         parse_stack_save(stack, ol);
         break;

--- a/wrapper/wrapper.c
+++ b/wrapper/wrapper.c
@@ -262,10 +262,12 @@ static int leave_block_callback(MD_BLOCKTYPE type, void *detail, void *userdata)
         MD_BLOCK_UL_DETAIL ul_detail = stack->details[stack->top].ul_details;
         uint8_t is_tight = ul_detail.is_tight ? 1 : 0;
         lean_object *items = parse_stack_pop(stack);
-        lean_object *ul = lean_alloc_ctor(1, 2, 1);
-        lean_ctor_set(ul, 0, lean_box_uint32(ul_detail.mark));
-        lean_ctor_set(ul, 1, items);
-        lean_ctor_set_uint8(ul, 2 * sizeof(void *), is_tight);
+
+        lean_object *ul = lean_alloc_ctor(1, 1, 5); // 4 bytes for char, 1 for bool
+        lean_ctor_set(ul, 0, items);
+        lean_ctor_set_uint32(ul, sizeof(void*), ul_detail.mark);
+        lean_ctor_set_uint8(ul, sizeof(void *) + sizeof(uint32_t), is_tight);
+
         parse_stack_save(stack, ul);
         break;
     }
@@ -282,11 +284,11 @@ static int leave_block_callback(MD_BLOCKTYPE type, void *detail, void *userdata)
         MD_BLOCK_OL_DETAIL ol_detail = stack->details[stack->top].ol_details;
         uint8_t is_tight = ol_detail.is_tight ? 1 : 0;
         lean_object *items = parse_stack_pop(stack);
-        lean_object *ol = lean_alloc_ctor(2, 3, 1);
+        lean_object *ol = lean_alloc_ctor(2, 2, 5); // 4 bytes for char, 1 for bool
         lean_ctor_set(ol, 0, lean_unsigned_to_nat(ol_detail.start));
-        lean_ctor_set(ol, 1, lean_box_uint32(ol_detail.mark_delimiter));
-        lean_ctor_set(ol, 2, items);
-        lean_ctor_set_uint8(ol, 3 * sizeof(void *), is_tight);
+        lean_ctor_set(ol, 1, items);
+        lean_ctor_set_uint32(ol, 2 * sizeof(void*), ol_detail.mark_delimiter);
+        lean_ctor_set_uint8(ol, 2 * sizeof(void *) + sizeof(uint32_t), is_tight);
         parse_stack_save(stack, ol);
         break;
     }


### PR DESCRIPTION
See https://github.com/leanprover/lean4/pull/9088 and https://github.com/leanprover/lean4/pull/9112 for details. This requires, and is required by, nightlies from 2025-07-01 and onward.

I don't think this should be merged right now, because it's not compatible with the latest releases, but it'll likely be useful to have around when the time comes. I think it's fine, but it's marked "draft" to make sure the timing is considered.