### PR TITLE
chore: bump toolchain and CI to recent versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Here, "original" means to use the lean-toolchain file's contents in the repository
-        lean-version: ["original", "v4.21.0", "v4.22.0-rc3", "nightly-2025-08-04"]
+        lean-version: ["original", "v4.21.0", "v4.22.0", "v4.23.0-rc2", "nightly-2025-08-20"]
     name: CI (${{ matrix.lean-version }})
 
     steps:

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.22.0-rc4
+leanprover/lean4:4.23.0-rc2


### PR DESCRIPTION
This updates the versions used in CI to recent ones, and sets the toolchain file to the latest RC.