### PR TITLE
chore: bump lean-toolchain to 4.31

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0-rc1
+leanprover/lean4:v4.31.0


### PR DESCRIPTION
Bump `lean-toolchain` to `leanprover/lean4:v4.31.0`.